### PR TITLE
Grant the called workflow what it declares

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,12 @@ jobs:
   # The full 3-OS three-layer matrix must also be green before any release build (workflow_call into test.yml).
   test-full:
     uses: ./.github/workflows/test.yml
+    # A called workflow's jobs get only what the caller grants, and the grant is validated when the
+    # file is parsed — test.yml's `pages` job declares these even though its `if:` keeps it off a tag.
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
 
   build:
     needs: [test, test-full]


### PR DESCRIPTION
Tagging v0.4.0 failed before a single job ran:

  Error calling workflow 'test.yml'. The nested job
  'pages' is requesting 'pages: write, id-token: write',
  but is only allowed 'pages: none, id-token: none'.

A called workflow's jobs get only what the calling job grants, and that grant is checked when the file is parsed. test.yml's pages job is guarded by
`if: github.ref == 'refs/heads/main'` so it can never run on a tag -- but an `if:` is evaluated long after parsing, so the guard bought nothing.

publish.yml declared no permissions at all, so
test-full offered none.

Worth naming: publish.yml is only ever exercised by a tag. test.yml runs on every push and cannot validate it, so this class of error costs a tag every time.