### PR TITLE
The artifact repo gets everything, or it rots

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -41,8 +41,18 @@ jobs:
           git clone --depth 1 git@github.com:toshas/ImageCompare_standalone.git artifact-repo
           cp dist/standalone/image_compare.html artifact-repo/image_compare.html
           cp standalone/README.artifact.md artifact-repo/README.md
+          # Copied, not maintained there: a second copy that can drift is worse than no copy.
+          cp LICENSE artifact-repo/LICENSE
+          cp CHANGELOG.md artifact-repo/CHANGELOG.md
+          # Development instructions in a repo whose README forbids development are actively misleading.
+          rm -f artifact-repo/CLAUDE.md
+          VERSION=$(node -p "require('./package.json').version")
+          sed -i "s|__VERSION__|${VERSION}|g; s|__COMMIT__|${GITHUB_SHA}|g" artifact-repo/README.md
+          if grep -q '__VERSION__\|__COMMIT__' artifact-repo/README.md; then
+            echo "::error::README placeholders were not substituted"; exit 1
+          fi
           cd artifact-repo
-          git add image_compare.html README.md
+          git add -A
           if git diff --cached --quiet; then
             echo "Artifact unchanged - nothing to push."
             exit 0

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -169,10 +169,13 @@ seam drives the drop handler's non-FSA branch directly.
 
 `.github/workflows/standalone.yml` rebuilds the page on every main push, uploads it as the
 `standalone-html` run artifact, and — once the `STANDALONE_DEPLOY_KEY` secret holds a write-access
-deploy key for `toshas/ImageCompare_standalone` — pushes it there together with
-`standalone/README.artifact.md` as that repo's README (commits only when the bytes changed). The
-Pages site serves the same page at `/standalone/`. The artifact repo is generated-only: it is never
-edited by hand, and the README it receives says so.
+deploy key for `toshas/ImageCompare_standalone` — pushes it there (commits only when the bytes
+changed). Four files are written: the page, `standalone/README.artifact.md` as that repo's README
+with `__VERSION__`/`__COMMIT__` substituted, plus `LICENSE` and `CHANGELOG.md` copied verbatim so
+neither can drift from this repo's. `CLAUDE.md` is deleted there: development instructions in a
+repo whose README forbids development are worse than none, and the deploy is the only thing that
+can remove them. The Pages site serves the same page at `/standalone/`. The artifact repo is
+generated-only: it is never edited by hand, and the README it receives says so at the top.
 
 ## Invariants
 

--- a/standalone/README.artifact.md
+++ b/standalone/README.artifact.md
@@ -1,31 +1,56 @@
 # ImageCompare (standalone)
 
-**This repository is a build artifact.** `image_compare.html` is generated from
-[toshas/ImageCompare_vscode](https://github.com/toshas/ImageCompare_vscode) on every push to its
-main branch — the matcher, viewer, voting, crop and PPTX logic are the *same code* the VS Code
-extension ships. Do not edit the file or open PRs here; report issues and contribute in the
-extension repo.
+A single self-contained HTML file for comparing image sets across modalities in a browser — no
+install, no server, no network.
+
+> **Generated file. Do not push to this repository, ever.**
+> `image_compare.html` is built from
+> [toshas/ImageCompare_vscode](https://github.com/toshas/ImageCompare_vscode) on every push to its
+> `main` branch. This repository is a *build artifact* of that one: anything committed here is
+> overwritten by the next build without review.
+>
+> **Bugs, feature requests and pull requests belong in
+> [toshas/ImageCompare_vscode](https://github.com/toshas/ImageCompare_vscode/issues)** — not here.
+> Issues opened against this repository cannot be fixed here, because the code that produced the
+> file does not live here.
+
+Built from `__COMMIT__` — version `__VERSION__`.
 
 ## Use
 
-Download `image_compare.html`, open it in a browser, pick (or drop) a folder whose subdirectories
-each hold one modality of the same image set.
+Download `image_compare.html` and open it in a browser. Pick (or drag in) a folder whose
+subdirectories each hold one modality of the same image set; files are matched into tuples by name.
 
-- **Chrome / Edge** — full features: voting saved to `results.txt` in the folder, crop written back
-  to every modality, delete, PPTX export.
-- **Firefox / Safari** — read-only: view and compare (folder-picker), PPTX export; anything that
-  writes files is disabled (these browsers don't expose writable folder access).
+| | Chrome / Edge | Firefox / Safari |
+|---|---|---|
+| view, compare, zoom, pan | yes | yes |
+| winner voting | yes, saved to `results.txt` in the folder | in-session only |
+| crop written back to every modality | yes | no |
+| delete | yes | no |
+| PPTX export | yes | yes |
+| live folder polling (new, renamed and deleted files) | yes | no |
 
-## Changes vs. the old hand-written standalone
+The split is not a feature decision: writing to a folder needs the File System Access API, which
+Chrome and Edge expose and Firefox and Safari do not. Those browsers fall back to a read-only
+folder listing, so everything that would modify your files is disabled rather than silently failing.
 
-This generated version replaces the previous independent implementation. Behavior follows the
-extension everywhere the two disagreed, most visibly:
+Dragging a folder in gives a read-only session even on Chrome. Use the folder **picker** if you
+want voting, crop or delete.
 
-- Matching edge cases can group differently (the extension's trie matcher is the single source of
-  truth now).
-- Rows sort by tuple name, so crops list directly under their parents.
-- Modality columns sort naturally (`mod2` before `mod10`), which can shift digit-key bindings and
-  colors.
-- Duplicate tuple names get ` (2)`-style suffixes instead of colliding.
-- Single-tuple folders are votable.
-- Live folder polling (auto-detecting new/deleted files) is not yet available.
+## Same code as the extension
+
+The matcher, viewer, voting, crop, PPTX export, deletion and polling are the *same modules* the VS
+Code extension ships — not a reimplementation. The two products differ only in what they are wired
+to: a browser's File System Access API here, the VS Code filesystem API there. A CI gate fails the
+build if either side hand-implements a decision the other shares.
+
+## Changelog
+
+`CHANGELOG.md` is copied verbatim from the extension repository, so most entries describe the VS
+Code extension. Entries that touch the shared modules — matching, crop, PPTX, results, thumbnail
+ordering — apply here too; entries about VS Code panels, commands, packaging or marketplace
+publishing do not.
+
+## License
+
+MIT, same as the extension. See `LICENSE`.


### PR DESCRIPTION
That repo has been untouched since February and still holds the old hand-written 133K page, plus a CLAUDE.md explaining how to develop there -- in a repo whose README says never to. The deploy wrote only the page and the README, and never removed anything, so those files would have outlived every future build.

It now also copies LICENSE and CHANGELOG.md, deletes CLAUDE.md, and substitutes the version and source
commit into the README, failing loudly if either
placeholder survives.

The README is rewritten. It leads with "do not push here, ever" and sends bugs and pull requests to the extension repo, because an issue filed there cannot be fixed there. The "changes vs. the old hand-written standalone" section is gone -- it described a
migration that is now history -- and with it a claim that had become false: live folder polling is not
"not yet available", it has been there since the poll work landed. The browser split is now a table, and says why it exists rather than reading as a feature decision. A note explains that the changelog is the extension's, so most entries are about the extension and only shared-module ones apply.

Simulated end to end against a replica of the repo's current contents: CLAUDE.md removed, four files
written, placeholders substituted, .gitignore left alone.